### PR TITLE
IBERT相关问题的初步修复

### DIFF
--- a/CORE/run_vivado_tcl.py
+++ b/CORE/run_vivado_tcl.py
@@ -43,13 +43,17 @@ def run_script_tcl(
     if not os.path.exists(tcl_script_path):
         raise RuntimeError(f"TCL脚本文件未找到: {tcl_script_path}")
     
+    # 获取脚本的绝对路径和目录
+    abs_tcl_script_path = os.path.abspath(tcl_script_path)
+    tcl_script_dir = os.path.dirname(abs_tcl_script_path)
+    
     # 构建命令
     cmd = [
         vivado_bat_path,
         "-mode", mode,
         "-log", log_file,
         "-journal", journal_file,
-        "-source", tcl_script_path
+        "-source", abs_tcl_script_path  # 使用绝对路径
     ]
     
     # 添加TCL参数
@@ -61,6 +65,8 @@ def run_script_tcl(
     logging.info(f"[run_script_tcl] 执行参数:")
     logging.info(f"  vivado_bin_path = {vivado_bin_path}")
     logging.info(f"  tcl_script_path = {tcl_script_path}")
+    logging.info(f"  abs_tcl_script_path = {abs_tcl_script_path}")
+    logging.info(f"  工作目录 = {tcl_script_dir}")
     logging.info(f"  tcl_args = {tcl_args}")
     logging.info(f"  log_file = {log_file}")
     logging.info(f"  journal_file = {journal_file}")
@@ -68,13 +74,14 @@ def run_script_tcl(
     logging.info(f"  命令: {' '.join(cmd)}")
     logging.info("=======================================================")
     
-    # 执行命令
+    # 执行命令，设置工作目录为脚本所在目录
     try:
         result = subprocess.run(
             cmd,
             capture_output=capture_output,
             text=True,
-            check=False  # 不自动抛出异常，让调用者处理
+            check=False,  # 不自动抛出异常，让调用者处理
+            cwd=tcl_script_dir  # 🔑 关键修改：设置工作目录
         )
         
         if result.returncode == 0:

--- a/RESOURCE/SCRIPTS/demo/ibert_api.tcl
+++ b/RESOURCE/SCRIPTS/demo/ibert_api.tcl
@@ -31,7 +31,7 @@ proc create_link {args} {
 }
 
 proc delete_link {link_name} {
-    remove_hw_sio_link [get_hw_sio_links -filte {DESCRIPTION == $link_name}]
+    remove_hw_sio_link [get_hw_sio_links -filter "DESCRIPTION == $link_name"]
 }
 
 proc set_link_property {args} {
@@ -55,7 +55,7 @@ proc set_link_property {args} {
     }
 
     if {[info exists params(-tx_post)]} {
-        set_property TXPOST $params(-tx_diff_swing) $link
+        set_property TXPOST $params(-tx_post) $link
     }
 
     if {[info exists params(-tx_diff_swing)]} {
@@ -90,9 +90,9 @@ proc tx_reset {args} {
     } else {
         set link [get_hw_sio_links]
     }
-    set_property PORT.GTRXRESET 1 $link
+    set_property PORT.GTTXRESET 1 $link
     commit_hw_sio $link
-    set_property PORT.GTRXRESET 0 $link
+    set_property PORT.GTTXRESET 0 $link
     commit_hw_sio $link
 }
 
@@ -127,4 +127,223 @@ proc scan {args} {
     wait_on_hw_sio_scan $xil_newScan
     set_property DESCRIPTION $params(-scan_name) $xil_newScan
     write_hw_sio_scan $params(-result_path) $xil_newScan -force
-} 
+}
+
+# 新增：多链路批量扫描函数（串行执行）
+proc scan_multi_links {args} {
+    array set params {
+        -link_names {"Link 0" "Link 1" "Link 2" "Link 3"}
+        -scan_name_prefix "Channel"
+        -scan_type 2d_full_eye 
+        -dwell_ber 1e-9
+        -result_path "./multi_channel_result.csv"
+        -temp_dir "./temp_scans"
+    }
+
+    array set params $args
+    
+    # 创建临时目录
+    file mkdir $params(-temp_dir)
+    
+    set temp_files {}
+    set valid_link_names {}
+    
+    # 串行执行每个链路的扫描
+    set channel_index 0
+    foreach link_name $params(-link_names) {
+        puts "Starting scan for $link_name..."
+        
+        set link [get_hw_sio_links -filter "DESCRIPTION == \"$link_name\""]
+        if {[llength $link] == 0} {
+            puts "Warning: Link $link_name not found, skipping..."
+            incr channel_index
+            continue
+        }
+        
+        set scan_name "$params(-scan_name_prefix) $channel_index"
+        set temp_file "$params(-temp_dir)/temp_$channel_index.csv"
+        
+        # 创建、运行并等待单个扫描完成
+        set xil_newScan [create_hw_sio_scan -description $scan_name $params(-scan_type) $link]
+        set_property DWELL_BER $params(-dwell_ber) $xil_newScan
+        
+        puts "  Running scan for $link_name (Channel $channel_index)..."
+        run_hw_sio_scan $xil_newScan
+        wait_on_hw_sio_scan $xil_newScan
+        
+        # 保存扫描结果
+        write_hw_sio_scan $temp_file $xil_newScan -force
+        puts "  Completed scan for $link_name"
+        
+        lappend temp_files $temp_file
+        lappend valid_link_names $link_name
+        
+        incr channel_index
+    }
+    
+    # 生成两种格式的输出文件
+    if {[llength $temp_files] > 0} {
+        # 1. 生成横向元数据格式
+        set metadata_file [file rootname $params(-result_path)]_metadata.csv
+        merge_metadata_horizontal $temp_files $metadata_file $valid_link_names
+        puts "Metadata format saved to: $metadata_file"
+        
+        # 2. 生成完整数据格式（包括2D数据）
+        merge_csv_files_complete $temp_files $params(-result_path) $valid_link_names
+        puts "Complete data format saved to: $params(-result_path)"
+        
+        puts "Multi-link scan completed with dual output formats!"
+    } else {
+        puts "No valid links found for scanning."
+    }
+    
+    # 清理临时文件
+    file delete -force $params(-temp_dir)
+}
+
+# 新增：提取元数据的函数
+proc extract_metadata {csv_file} {
+    if {![file exists $csv_file]} {
+        puts "Warning: File $csv_file not found"
+        return [list {} {}]
+    }
+    
+    set input_fd [open $csv_file r]
+    set attributes {}
+    set values {}
+    
+    while {[gets $input_fd line] >= 0} {
+        set clean_line [string trim $line]
+        
+        # 跳过空行
+        if {$clean_line eq ""} continue
+        
+        # 停止条件：遇到2d statistical或Scan Start就停止
+        if {[string match "*2d statistical*" $clean_line]} break
+        if {[string match "*Scan Start*" $clean_line]} break
+        
+        # 跳过特殊行
+        if {[string match "*Misc Info*" $clean_line]} continue
+        
+        # 解析属性-值对
+        set parts [split $clean_line ","]
+        if {[llength $parts] >= 2} {
+            set attr [string trim [lindex $parts 0] "\r\n "]
+            set val [string trim [lindex $parts 1] "\r\n "]
+            
+            lappend attributes $attr
+            lappend values $val
+        }
+    }
+    
+    close $input_fd
+    return [list $attributes $values]
+}
+
+# 修改后的CSV合并函数：横向元数据格式
+proc merge_metadata_horizontal {temp_files output_file link_names} {
+    set output_fd [open $output_file w]
+    
+    set all_attributes {}
+    set all_link_data {}
+    
+    # 处理每个临时文件
+    foreach temp_file $temp_files link_name $link_names {
+        puts "Processing metadata for $link_name..."
+        
+        set metadata_result [extract_metadata $temp_file]
+        set attributes [lindex $metadata_result 0]
+        set values [lindex $metadata_result 1]
+        
+        # 第一个文件：设置属性名作为表头
+        if {[llength $all_attributes] == 0} {
+            set all_attributes $attributes
+        }
+        
+        # 存储每个链路的数据
+        lappend all_link_data [list $link_name $values]
+    }
+    
+    # 写入表头（属性名）
+    if {[llength $all_attributes] > 0} {
+        puts -nonewline $output_fd [lindex $all_attributes 0]
+        for {set i 1} {$i < [llength $all_attributes]} {incr i} {
+            puts -nonewline $output_fd ",[lindex $all_attributes $i]"
+        }
+        puts $output_fd ""
+        
+        # 写入每个链路的数据行
+        foreach link_data $all_link_data {
+            set link_name [lindex $link_data 0]
+            set values [lindex $link_data 1]
+            
+            if {[llength $values] > 0} {
+                puts -nonewline $output_fd [lindex $values 0]
+                for {set i 1} {$i < [llength $values]} {incr i} {
+                    set val [lindex $values $i]
+                    # 如果值包含逗号，用引号包围
+                    if {[string match "*,*" $val]} {
+                        puts -nonewline $output_fd ",\"$val\""
+                    } else {
+                        puts -nonewline $output_fd ",$val"
+                    }
+                }
+                puts $output_fd ""
+            }
+        }
+        
+        puts "Horizontal metadata format created successfully!"
+        puts "- Header row: [llength $all_attributes] attributes"
+        puts "- Data rows: [llength $all_link_data] links"
+    } else {
+        puts "No metadata found in input files."
+    }
+    
+    close $output_fd
+}
+
+# 新增：完整CSV合并函数（保留原始格式，包括2D数据）
+proc merge_csv_files_complete {temp_files output_file link_names} {
+    set output_fd [open $output_file w]
+    
+    set first_file 1
+    set channel_index 0
+    
+    foreach temp_file $temp_files link_name $link_names {
+        if {![file exists $temp_file]} {
+            puts "Warning: Temp file $temp_file not found"
+            incr channel_index
+            continue
+        }
+        
+        set input_fd [open $temp_file r]
+        set line_num 0
+        
+        while {[gets $input_fd line] >= 0} {
+            incr line_num
+            
+            # 处理头部
+            if {$line_num == 1} {
+                if {$first_file} {
+                    # 第一个文件：添加Channel列并写入头部
+                    puts $output_fd "Channel,$line"
+                    set first_file 0
+                }
+                continue
+            }
+            
+            # 处理数据行：添加通道信息
+            if {$line != ""} {
+                puts $output_fd "$link_name,$line"
+            }
+        }
+        
+        close $input_fd
+        incr channel_index
+    }
+    
+    close $output_fd
+    puts "Complete data format created successfully!"
+    puts "- Includes all metadata and 2D eye diagram data"
+    puts "- Channel column added for identification"
+}

--- a/RESOURCE/SCRIPTS/demo/ibert_example.tcl
+++ b/RESOURCE/SCRIPTS/demo/ibert_example.tcl
@@ -1,6 +1,6 @@
 #导入ibert库
-# source "./iber.tcl"
-source "E:\\workspace\\AutoTestTool\\iber.tcl"
+source "./ibert_api.tcl"
+# source "E:\\workspace\\AutoTestTool\\iber.tcl"
 
 # ---------- 连接器件烧写测试码流 ---------------------
 open_hw_manager
@@ -32,9 +32,12 @@ create_link -tx_nub 3 -rx_nub 3 -link_name "Link 3"
 
 # 对所有的link的tx pattern设置为 PRBS 15-bit
 set_link_property -tx_pattern "PRBS 15-bit"
+set_link_property -rx_pattern "PRBS 7-bit"
 
 # 对Link 0的tx pattern设置为 PRBS 7-bit
 set_link_property -link_name "Link 0" -tx_pattern "PRBS 7-bit"
+# 对Link 0的rx pattern设置为 PRBS 7-bit
+set_link_property -link_name "Link 0" -rx_pattern "PRBS 7-bit"
 
 # 对link进行复位。当不指定link_name时,对所有link生效
 
@@ -48,9 +51,41 @@ ibert_reset
 rx_reset
 tx_reset
 
-# 运行眼图扫描，将测试结果保存到-resul_path指定的文件中
-scan -link_name "Link 0" -scan_name "Channel 0" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 0.csv"
-scan -link_name "Link 1" -scan_name "Channel 1" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 1.csv"
-scan -link_name "Link 2" -scan_name "Channel 2" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 2.csv"
-scan -link_name "Link 3" -scan_name "Channel 3" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 3.csv"
+# # 运行眼图扫描，将测试结果保存到-resul_path指定的文件中
+# scan -link_name "Link 0" -scan_name "Channel 0" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 0.csv"
+# scan -link_name "Link 1" -scan_name "Channel 1" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 1.csv"
+# scan -link_name "Link 2" -scan_name "Channel 2" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 2.csv"
+# scan -link_name "Link 3" -scan_name "Channel 3" -scan_type 2d_full_eye -dwell_ber 1e-9 -result_path "./result 3.csv"
+# ------------------------------------------------------------
+
+# ============= 多链路批量扫描，生成双格式输出 =============
+
+# puts "开始执行多链路批量扫描..."
+
+# 一次性扫描所有4个通道，生成两种格式的结果文件：
+# 1. all_channels_result.csv - 完整数据（包括2D眼图数据）
+# 2. all_channels_result_metadata.csv - 横向元数据格式
+scan_multi_links \
+    -link_names {"Link 0" "Link 1" "Link 2" "Link 3"} \
+    -scan_name_prefix "Channel" \
+    -scan_type 2d_full_eye \
+    -dwell_ber 1e-9 \
+    -result_path "./all_channels_result.csv"
+
+# puts "所有扫描任务完成！"
+# puts ""
+# puts "生成的文件："
+# puts "1. all_channels_result.csv - 完整数据格式"
+# puts "   - 包含所有元数据和2D眼图数据"
+# puts "   - 格式与原始paste.txt相同"
+# puts "   - 可作为Excel第二个sheet"
+# puts ""
+# puts "2. all_channels_result_metadata.csv - 横向元数据格式"
+# puts "   - 第一行：属性名"
+# puts "   - 第二行：Link 0的值"
+# puts "   - 第三行：Link 1的值"
+# puts "   - 第四行：Link 2的值"
+# puts "   - 第五行：Link 3的值"
+# puts "   - 已舍弃2D统计数据部分"
+# puts "   - 可作为Excel第一个sheet"
 # ------------------------------------------------------------


### PR DESCRIPTION
1.解决ibert_example.tcl相对导入其他tcl的引用问题
2.修复原本的ibert_api.tcl的脚本错误
3.对于IBERT眼图测试结果的优化，完善ibert_example.tcl和ibert_api.tcl，使得最终单次测试结果为包含4个channel的总表，而不再是4个单独针对每个channel的表。all_channels_result.csv和all_channels_result_metadata.csv